### PR TITLE
Fix unreadable text in amount field

### DIFF
--- a/src/main/java/software/ulpgc/apps/swing/content/SwingMoneyDialog.java
+++ b/src/main/java/software/ulpgc/apps/swing/content/SwingMoneyDialog.java
@@ -26,7 +26,7 @@ public class SwingMoneyDialog extends JPanel implements MoneyDialog {
 
         textField.setFont(new Font("Arial", Font.PLAIN, 12));
         textField.setForeground(Color.WHITE);
-        textField.setBackground(new Color(255,255,255));
+        textField.setBackground(new Color(44, 44, 46));
         textField.setCaretColor(Color.WHITE);
         textField.setBorder(new SwingRoundedBorder(1));
 


### PR DESCRIPTION
## Summary
- fix the text field background so input text is visible

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bf3160cf083248f7dd2b706aff741